### PR TITLE
adding a possibility to replace the progress bar with a custom text indicating a status

### DIFF
--- a/cmd/progress-bar.go
+++ b/cmd/progress-bar.go
@@ -31,6 +31,8 @@ type PBar struct {
 		Xpixel uint16 // X pixel
 		Ypixel uint16 // Y pixel
 	}
+	CustomMsg    string // Custom message
+	CustomPrompt string // Custom prompt
 }
 
 // NewPBar create a new progress bar
@@ -50,6 +52,7 @@ func NewPBar() *PBar {
 		ongoingStr:  ".",
 		signalWinch: make(chan os.Signal, 1),
 		signalTerm:  make(chan os.Signal, 1),
+		CustomMsg:   "",
 	}
 
 	signal.Notify(pb.signalWinch, syscall.SIGWINCH) // Register SIGWINCH signal
@@ -130,6 +133,15 @@ func (pb *PBar) RenderPBar(count int) {
 	todo := strings.Repeat(pb.ongoingStr, barWidth-barDone)                // Fill the bar with todo string
 	bar := fmt.Sprintf("[%s%s]", done, todo)                               // Combine the done and todo string
 
+	if pb.CustomMsg != "" {
+		bar = pb.CustomMsg
+	}
+
+	prompt := "Progress: "
+	if pb.CustomPrompt != "" {
+		prompt = fmt.Sprintf(pb.CustomPrompt)
+	}
+
 	fmt.Printf("\x1B[%d;%dH", pb.wsrow, 0) // move cursor to row #, col #
 
 	switch {
@@ -138,7 +150,7 @@ func (pb *PBar) RenderPBar(count int) {
 	case pb.wscol >= uint16(10) && pb.wscol <= uint16(20):
 		fmt.Printf("[\x1B[33m%3d%%\x1B[0m] %s", uint16(count)*100/pb.Total, bar)
 	default:
-		fmt.Printf("Progress: [\x1B[33m%3d%%\x1B[0m] %s", uint16(count)*100/pb.Total, bar)
+		fmt.Printf("%s[\x1B[33m%3d%%\x1B[0m] %s", prompt, uint16(count)*100/pb.Total, bar)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"time"
 
 	cmd "github.com/elulcao/progress-bar/cmd"
@@ -9,13 +9,31 @@ import (
 
 func main() {
 	pb := cmd.NewPBar()
+	pb.CustomMsg = " "
 	pb.SignalHandler()
-	pb.Total = uint16(100)
+	pb.Total = uint16(10)
+
+	mockLogMessages := []string{
+		"Starting the application...",
+		"Printing more messages...",
+		"sending a message...",
+		"receiving a message...",
+		"receiving a message...",
+		"receiving a message...",
+		"receiving a message...",
+		"receiving a message...",
+		"receiving a message...",
+		"receiving a message...",
+		"receiving a message...",
+		"receiving a message...",
+	}
 
 	for i := 1; uint16(i) <= pb.Total; i++ {
 		pb.RenderPBar(i)
-		fmt.Println(i)              // Do something here
-		time.Sleep(1 * time.Second) // Wait 1 second, for demo purpose
+		pb.CustomMsg = mockLogMessages[i-1]
+		log.Println(mockLogMessages[i-1])
+		// log.Println(i)               // Do something here
+		time.Sleep(5 * time.Second) // Wait 1 second, for demo purpose
 	}
 
 	pb.CleanUp()


### PR DESCRIPTION
This PR should add a possibility to replace the rendered progress bar with a custom status text.

added
- PBar.CustomMsg -> if set replaces the progress bar
- PBar.CustomPrompt -> if set replaces the prompt which is by default "Progress: "